### PR TITLE
Use books endpoint to retrieve all book info in a single request

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,18 +1,18 @@
-const endpoint = isbn => `https://openlibrary.org/isbn/${isbn}.json`
+const endpoint = isbn => `https://openlibrary.org/api/books?bibkeys=ISBN:${isbn}&jscmd=data&format=json`
 
 export const fetchBookInfo = async (isbn) => {
   const resp = await fetch(endpoint(isbn))
   const data = await resp.json()
+  const info = data[`ISBN:${isbn}`]
 
-  const title = data.title
-  const publishDate = data.publish_date
-  // TODO: Resolve authors info as a comma separated list
-  const author = data.authors[0].key
+  const title = info.title
+  const publishDate = info.publish_date
+  const authors = info.authors.map(author => author.name).join(", ")
 
   return {
     isbn,
     title,
-    author,
+    authors,
     publishDate
   }
 }

--- a/src/components/Books/index.jsx
+++ b/src/components/Books/index.jsx
@@ -5,7 +5,7 @@ export default function Books({ books = [] }) {
         <tr>
           <th>ISBN</th>
           <th>Title</th>
-          <th>Author</th>
+          <th>Author(s)</th>
           <th>Publish Date</th>
         </tr>
       </thead>
@@ -14,7 +14,7 @@ export default function Books({ books = [] }) {
           <tr key={book.isbn}>
             <td>{book.isbn}</td>
             <td>{book.title}</td>
-            <td>{book.author}</td>
+            <td>{book.authors}</td>
             <td>{book.publishDate}</td>
           </tr>
         ))}


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

Resolves #1 

### Description

This updates the endpoint used to fetch book information from [openlibrary.org](https://openlibrary.org/) with one that provides all the needed data within the same request (such as authors).

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

1. Enter an ISBN code in the input field or Scan a book barcode;
2. Verify the author information is now present in the scanned books table;

### Screenshots

![2021-10-12 12 08 43](https://user-images.githubusercontent.com/508128/136982889-8107887b-a564-4a0e-9511-ffdb70314d75.gif)

