### PR TITLE
Export scanned books to a CSV file

### DIFF
--- a/src/components/Books/index.jsx
+++ b/src/components/Books/index.jsx
@@ -1,13 +1,4 @@
-function createCsvItem(book) {
-  return Object.values(book).map(JSON.stringify).join(",")
-}
-
-function jsonToCsv(books = []) {
-  const header = Object.keys(books[0]).join(",")
-  const items = books.map(createCsvItem).join("\n")
-
-  return `${header}\n${items}`
-}
+import { jsonToCsv } from "../../helpers/csv"
 
 export default function Books({ books = [] }) {
   const blob = new Blob([jsonToCsv(books)], { type: "text/csv" })

--- a/src/helpers/csv.jsx
+++ b/src/helpers/csv.jsx
@@ -1,0 +1,10 @@
+function createCsvItem(book) {
+  return Object.values(book).map(JSON.stringify).join(",")
+}
+
+export function jsonToCsv(books = []) {
+  const header = Object.keys(books[0]).join(",")
+  const items = books.map(createCsvItem).join("\n")
+
+  return `${header}\n${items}`
+}


### PR DESCRIPTION
Resolves #5

### Description

Allow users to export the scanned books to a CSV file.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

1. Scan a few books;
2. Click the `Export CSV` link to the right of the table;
3. Verify the exported CSV data match the scanned information.

### Screenshots

![2021-10-12 17 42 12](https://user-images.githubusercontent.com/508128/137026225-40d24965-f102-4f39-880b-eed6f9761659.gif)

